### PR TITLE
feat(memberships): implementa el CRUD completo para Planes

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -3,13 +3,15 @@ import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { FirebaseModule } from './firebase/firebase.module';
 import { ConfigModule } from '@nestjs/config';
+import { MembershipsModule } from './memberships/memberships.module';
 
 @Module({
   imports: [
     ConfigModule.forRoot({
       isGlobal: true
     }),
-    FirebaseModule],
+    FirebaseModule,
+    MembershipsModule],
   controllers: [AppController],
   providers: [AppService],
 })

--- a/src/common/filters/domain-exception.filter.ts
+++ b/src/common/filters/domain-exception.filter.ts
@@ -1,0 +1,46 @@
+import { ExceptionFilter, Catch, ArgumentsHost, BadRequestException } from '@nestjs/common';
+import { Response } from 'express';
+import {
+    DomainException,
+    InvalidPlanDurationException,
+    InvalidPlanNameException,
+    InvalidPlanPriceException,
+    PlanNotFoundException
+} from 'src/memberships/domain/exceptions/plan.exceptions';
+
+@Catch(DomainException) // Atrapa todas las excepciones que hereden de DomainException
+export class DomainExceptionFilter implements ExceptionFilter {
+    catch(exception: DomainException, host: ArgumentsHost) {
+        const ctx = host.switchToHttp();
+        const response = ctx.getResponse<Response>();
+
+        let status = 500; // Por defecto Internal Server Error
+
+        // Mapea excepciones específicas a códigos de estado HTTP
+        if (
+            exception instanceof InvalidPlanNameException ||
+            exception instanceof InvalidPlanPriceException ||
+            exception instanceof InvalidPlanDurationException
+        ) {
+            status = 400; // Bad Request
+        }
+
+        if (exception instanceof PlanNotFoundException) {
+            status = 404; // Not Found
+        }
+
+        // Podrías añadir más mapeos aquí:
+        // if (exception instanceof MemberNotFoundException) {
+        //   status = 404; // Not Found
+        // }
+
+        response
+            .status(status)
+            .json({
+                statusCode: status,
+                message: exception.message,
+                error: exception.name,
+                timestamp: new Date().toISOString(),
+            });
+    }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,6 +4,7 @@ import { ConfigService } from '@nestjs/config';
 import { Logger, ValidationPipe } from '@nestjs/common';
 import helmet from 'helmet';
 import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
+import { DomainExceptionFilter } from './common/filters/domain-exception.filter';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule, {
@@ -26,6 +27,8 @@ async function bootstrap() {
       },
     }),
   );
+
+  app.useGlobalFilters(new DomainExceptionFilter());
 
   const swaggerConfig = new DocumentBuilder()
     .setTitle('API del Proyecto')

--- a/src/memberships/README.md
+++ b/src/memberships/README.md
@@ -1,0 +1,78 @@
+# Contexto Delimitado: Membresías (Memberships)
+
+## Responsabilidad Principal
+
+Este directorio contiene toda la lógica de negocio relacionada con el **Dominio Core** del sistema: la gestión del ciclo de vida de los **Planes** y, futuramente, de los **Miembros** y sus **Membresías**.
+
+Es la fuente de verdad para preguntas como:
+- ¿Qué planes ofrecemos?
+- ¿Cuáles son las reglas de negocio para un plan?
+- ¿Un miembro tiene una membresía activa?
+
+## 🏛️ Arquitectura Interna
+
+Este contexto sigue estrictamente los principios de la Arquitectura Limpia (o Hexagonal), separando las responsabilidades en tres capas principales:
+
+#### 📁 `domain`
+El corazón del contexto. Contiene la lógica de negocio pura, sin dependencias de frameworks o bases de datos.
+- **Entidades (`/entities`):** Objetos de negocio con identidad y reglas (invariantes), como `Plan`.
+- **Repositorios (`/repositories`):** Interfaces (contratos) que definen cómo se persiste el dominio, como `PlanRepository`.
+- **Excepciones (`/exceptions`):** Errores de negocio personalizados, como `PlanNotFoundException`.
+
+#### 📁 `application`
+La capa que orquesta el dominio. No contiene lógica de negocio, solo coordina los pasos para ejecutar una acción.
+- **Casos de Uso (`/`):** Clases que representan una única acción del sistema, como `CreatePlanUseCase` o `UpdatePlanUseCase`.
+
+#### 📁 `infrastructure`
+Los detalles externos y la comunicación con el mundo exterior. Es la única capa que conoce a NestJS y Firestore.
+- **Controladores (`/controllers`):** Exponen los casos de uso a través de endpoints HTTP. Incluye los DTOs para validación de entrada/salida.
+- **Persistencia (`/persistence`):** La implementación concreta de las interfaces del repositorio, como `FirestorePlanRepository`.
+
+## ✨ Modelo de Dominio Actual
+
+### Entidad `Plan`
+Representa una plantilla para una membresía que puede ser vendida. Es responsable de mantener sus propias reglas de negocio (invariantes). Por ejemplo, un `Plan` no puede tener un precio negativo y su nombre no puede estar vacío. Toda la creación y modificación se realiza a través de sus métodos internos para garantizar su validez.
+
+### Repositorio `PlanRepository`
+Es el contrato que define las operaciones de persistencia necesarias para la entidad `Plan` (`save`, `findById`, `findAll`), desacoplando el dominio de Firestore.
+
+## 📋 Casos de Uso Implementados
+
+Este módulo actualmente soporta los siguientes casos de uso para la gestión de `Planes`:
+
+* **`CreatePlanUseCase`**: Orquesta la creación de una nueva entidad `Plan` y su persistencia.
+* **`UpdatePlanUseCase`**: Orquesta la búsqueda, modificación y persistencia de un `Plan` existente.
+* **`DeactivatePlanUseCase`**: Maneja el borrado lógico (soft delete) de un `Plan`.
+* **`ActivatePlanUseCase`**: Invierte el borrado lógico, reactivando un `Plan`.
+* **`FindAllPlansUseCase`**: Recupera todos los `Planes` y los mapea a un DTO de respuesta.
+* **`FindOnePlanUseCase`**: Recupera un `Plan` específico por su ID.
+
+## 🔌 API Endpoints
+
+Este contexto expone los siguientes endpoints bajo el prefijo `/plans`:
+
+| Verbo | Ruta | Descripción | DTO (Entrada) |
+| :--- | :--- | :--- | :--- |
+| `POST` | `/` | Crea un nuevo plan. | `CreatePlanDto` |
+| `GET` | `/` | Obtiene una lista de todos los planes. | `N/A` |
+| `GET` | `/:id` | Obtiene un plan específico por su ID. | `N/A` |
+| `PATCH` | `/:id` | Modifica parcialmente un plan existente. | `UpdatePlanDto` |
+| `DELETE`| `/:id` | Desactiva un plan (Soft Delete).| `N/A` |
+| `POST` | `/:id/activate`| Reactiva un plan previamente desactivado. | `N/A` |
+
+## ⚙️ Flujo de una Petición (Ej: Crear un Plan)
+
+1.  Una petición `POST` llega a `/plans` con un JSON en el body.
+2.  El `MembershipsController` recibe la petición. El `ValidationPipe` de NestJS valida el `CreatePlanDto` automáticamente.
+3.  El controlador llama al método `execute()` de `CreatePlanUseCase`, pasándole los datos del DTO.
+4.  El caso de uso llama al método estático `Plan.create()` para crear una nueva instancia de la entidad. La entidad se valida a sí misma en su constructor.
+5.  El caso de uso invoca a `planRepository.save(plan)`.
+6.  NestJS, a través de la inyección de dependencias, resuelve `planRepository` a nuestra implementación `FirestorePlanRepository`.
+7.  `FirestorePlanRepository` mapea la entidad `Plan` a un objeto simple y lo persiste en la colección `plans` de Firestore.
+8.  La respuesta `201 Created` es enviada de vuelta al cliente.
+
+## 🚀 Cómo Extender
+Para añadir nueva funcionalidad a este contexto, sigue el patrón establecido:
+1.  **Dominio:** ¿Hay nuevas reglas o entidades? Modifica o crea entidades en la capa de `domain`.
+2.  **Aplicación:** Crea un nuevo `Caso de Uso` en la capa de `application` para orquestar la nueva funcionalidad.
+3.  **Infraestructura:** Expón el nuevo caso de uso a través de un nuevo método en el `MembershipsController`.

--- a/src/memberships/application/activate-plan.use-case.ts
+++ b/src/memberships/application/activate-plan.use-case.ts
@@ -1,0 +1,23 @@
+import { Injectable, Inject } from '@nestjs/common';
+import { PlanRepository } from '../domain/repositories/plan.repository';
+import { PlanNotFoundException } from '../domain/exceptions/plan.exceptions';
+
+@Injectable()
+export class ActivatePlanUseCase {
+    constructor(
+        @Inject(PlanRepository)
+        private readonly planRepository: PlanRepository,
+    ) { }
+
+    async execute(command: { id: string }): Promise<void> {
+        const plan = await this.planRepository.findById(command.id);
+
+        if (!plan) {
+            throw new PlanNotFoundException(`Plan con ID ${command.id} no encontrado.`);
+        }
+
+        plan.activate();
+
+        await this.planRepository.save(plan);
+    }
+}

--- a/src/memberships/application/create-plan.use-case.ts
+++ b/src/memberships/application/create-plan.use-case.ts
@@ -1,0 +1,26 @@
+// src/memberships/application/create-plan.use-case.ts
+
+import { Injectable, Inject } from '@nestjs/common';
+import { Plan, PlanProps } from '../domain/entities/plan.entity';
+import { PlanRepository } from '../domain/repositories/plan.repository';
+
+// Definimos una interfaz para los datos de entrada, es más limpio que usar la entidad directamente.
+export type CreatePlanCommand = Omit<PlanProps, 'id' | 'isActive'>;
+
+@Injectable()
+export class CreatePlanUseCase {
+    constructor(
+        @Inject(PlanRepository)
+        private readonly planRepository: PlanRepository,
+    ) { }
+
+    async execute(command: CreatePlanCommand): Promise<void> {
+
+        const plan = Plan.create({
+            ...command,
+            isActive: true,
+        });
+
+        await this.planRepository.save(plan);
+    }
+}

--- a/src/memberships/application/deactivate-plan.use-case.ts
+++ b/src/memberships/application/deactivate-plan.use-case.ts
@@ -1,0 +1,23 @@
+import { Injectable, Inject } from '@nestjs/common';
+import { PlanRepository } from '../domain/repositories/plan.repository';
+import { PlanNotFoundException } from '../domain/exceptions/plan.exceptions';
+
+@Injectable()
+export class DeactivatePlanUseCase {
+    constructor(
+        @Inject(PlanRepository)
+        private readonly planRepository: PlanRepository,
+    ) { }
+
+    async execute(command: { id: string }): Promise<void> {
+        const plan = await this.planRepository.findById(command.id);
+
+        if (!plan) {
+            throw new PlanNotFoundException(`Plan con ID ${command.id} no encontrado.`);
+        }
+
+        plan.deactivate();
+
+        await this.planRepository.save(plan);
+    }
+}

--- a/src/memberships/application/find-all-plans.use-case.ts
+++ b/src/memberships/application/find-all-plans.use-case.ts
@@ -1,0 +1,29 @@
+import { Injectable, Inject } from '@nestjs/common';
+import { Plan } from '../domain/entities/plan.entity';
+import { PlanRepository } from '../domain/repositories/plan.repository';
+import { PlanResponseDto } from '../infrastructure/controllers/dtos/plan-response.dto';
+
+@Injectable()
+export class FindAllPlansUseCase {
+    constructor(
+        @Inject(PlanRepository)
+        private readonly planRepository: PlanRepository,
+    ) { }
+
+    async execute(): Promise<PlanResponseDto[]> {
+        const plans = await this.planRepository.findAll();
+        return plans.map(plan => this.toResponseDto(plan));
+    }
+
+    private toResponseDto(plan: Plan): PlanResponseDto {
+        return {
+            id: plan.id,
+            name: plan.getName(),
+            description: plan.getDescription(),
+            price: plan.getPrice(),
+            durationValue: plan.getDurationValue(),
+            durationUnit: plan.getDurationUnit(),
+            isActive: plan.getIsActive(),
+        };
+    }
+}

--- a/src/memberships/application/find-one-plan.use-case.ts
+++ b/src/memberships/application/find-one-plan.use-case.ts
@@ -1,0 +1,35 @@
+import { Injectable, Inject } from '@nestjs/common';
+import { Plan } from '../domain/entities/plan.entity';
+import { PlanRepository } from '../domain/repositories/plan.repository';
+import { PlanNotFoundException } from '../domain/exceptions/plan.exceptions';
+import { PlanResponseDto } from '../infrastructure/controllers/dtos/plan-response.dto';
+
+@Injectable()
+export class FindOnePlanUseCase {
+    constructor(
+        @Inject(PlanRepository)
+        private readonly planRepository: PlanRepository,
+    ) { }
+
+    async execute(command: { id: string }): Promise<PlanResponseDto> {
+        const plan = await this.planRepository.findById(command.id);
+
+        if (!plan) {
+            throw new PlanNotFoundException(`Plan con ID ${command.id} no encontrado.`);
+        }
+
+        return this.toResponseDto(plan);
+    }
+
+    private toResponseDto(plan: Plan): PlanResponseDto {
+        return {
+            id: plan.id,
+            name: plan.getName(),
+            description: plan.getDescription(),
+            price: plan.getPrice(),
+            durationValue: plan.getDurationValue(),
+            durationUnit: plan.getDurationUnit(),
+            isActive: plan.getIsActive(),
+        };
+    }
+}

--- a/src/memberships/application/update-plan.use-case.ts
+++ b/src/memberships/application/update-plan.use-case.ts
@@ -1,0 +1,48 @@
+import { Injectable, Inject } from '@nestjs/common';
+import { PlanRepository } from '../domain/repositories/plan.repository';
+import { PlanDurationUnit } from '../domain/entities/plan.entity';
+import { PlanNotFoundException } from '../domain/exceptions/plan.exceptions';
+
+// Opcional: crea PlanNotFoundException en plan.exceptions.ts
+// export class PlanNotFoundException extends DomainException { ... }
+
+export interface UpdatePlanCommand {
+    id: string;
+    name?: string;
+    description?: string;
+    price?: number;
+    durationValue?: number;
+    durationUnit?: PlanDurationUnit;
+    isActive?: boolean;
+}
+
+@Injectable()
+export class UpdatePlanUseCase {
+    constructor(
+        @Inject(PlanRepository)
+        private readonly planRepository: PlanRepository,
+    ) { }
+
+    async execute(command: UpdatePlanCommand): Promise<void> {
+        // 1. Buscar la entidad existente
+        const plan = await this.planRepository.findById(command.id);
+
+        if (!plan) {
+            // 2. Si no existe, lanzamos un error de dominio específico
+            throw new PlanNotFoundException(`Plan con ID ${command.id} no encontrado.`);
+        }
+
+        // 3. Aplicar los cambios llamando a los métodos de la entidad
+        if (command.name !== undefined) plan.changeName(command.name);
+        if (command.description !== undefined) plan.changeDescription(command.description);
+        if (command.price !== undefined) plan.changePrice(command.price);
+        if (command.durationValue !== undefined && command.durationUnit !== undefined) {
+            plan.changeDuration(command.durationValue, command.durationUnit);
+        }
+        if (command.isActive === true) plan.activate();
+        if (command.isActive === false) plan.deactivate();
+
+        // 4. Persistir la entidad actualizada
+        await this.planRepository.save(plan);
+    }
+}

--- a/src/memberships/domain/entities/plan.entity.ts
+++ b/src/memberships/domain/entities/plan.entity.ts
@@ -1,0 +1,92 @@
+import { randomUUID } from 'crypto';
+import {
+    InvalidPlanDurationException,
+    InvalidPlanNameException,
+    InvalidPlanPriceException
+} from '../exceptions/plan.exceptions';
+
+export type PlanDurationUnit = 'days' | 'months' | 'years';
+
+export interface PlanProps {
+    id?: string;
+    name: string;
+    description: string;
+    price: number;
+    durationValue: number;
+    durationUnit: PlanDurationUnit;
+    isActive: boolean;
+}
+
+export class Plan {
+    public readonly id: string;
+    private name: string;
+    private description: string;
+    private price: number;
+    private durationValue: number;
+    private durationUnit: PlanDurationUnit;
+    private isActive: boolean;
+
+    private constructor(props: PlanProps) {
+        this.id = props.id || randomUUID();
+        this.name = props.name;
+        this.description = props.description;
+        this.price = props.price;
+        this.durationValue = props.durationValue;
+        this.durationUnit = props.durationUnit;
+        this.isActive = props.isActive;
+
+        this.validate();
+    }
+
+    public static create(props: PlanProps): Plan {
+        return new Plan(props);
+    }
+
+    getName(): string { return this.name; }
+    getDescription(): string { return this.description; }
+    getPrice(): number { return this.price; }
+    getDurationValue(): number { return this.durationValue; }
+    getDurationUnit(): PlanDurationUnit { return this.durationUnit; }
+    getIsActive(): boolean { return this.isActive; }
+
+    public deactivate(): void { this.isActive = false; }
+    public activate(): void { this.isActive = true; }
+
+    public changePrice(newPrice: number): void {
+        if (newPrice <= 0) {
+            throw new InvalidPlanPriceException();
+        }
+        this.price = newPrice;
+    }
+
+    public changeName(newName: string): void {
+        if (!newName || newName.trim().length === 0) {
+            throw new InvalidPlanNameException("El nuevo nombre del plan no puede estar vacío.");
+        }
+        this.name = newName;
+    }
+
+    public changeDescription(newDescription: string): void {
+        this.description = newDescription;
+    }
+
+    public changeDuration(newValue: number, newUnit: PlanDurationUnit): void {
+        if (newValue <= 0) {
+            throw new InvalidPlanDurationException("La nueva duración no puede ser menor a 0.");
+        }
+        this.durationValue = newValue;
+        this.durationUnit = newUnit;
+    }
+
+    private validate(): void {
+        if (!this.name || this.name.trim().length === 0) {
+            throw new InvalidPlanNameException();
+        }
+        if (this.price <= 0) {
+            throw new InvalidPlanPriceException();
+        }
+        if (this.durationValue <= 0) {
+            throw new InvalidPlanDurationException();
+        }
+    }
+}

--- a/src/memberships/domain/exceptions/plan.exceptions.ts
+++ b/src/memberships/domain/exceptions/plan.exceptions.ts
@@ -1,0 +1,30 @@
+export class DomainException extends Error {
+    constructor(message: string) {
+        super(message);
+        this.name = this.constructor.name;
+    }
+}
+
+export class InvalidPlanNameException extends DomainException {
+    constructor(message: string = "El nombre del plan no puede estar vacío.") {
+        super(message);
+    }
+}
+
+export class InvalidPlanPriceException extends DomainException {
+    constructor(message: string = "El precio debe ser un valor positivo.") {
+        super(message);
+    }
+}
+
+export class InvalidPlanDurationException extends DomainException {
+    constructor(message: string = "La duración debe ser un valor positivo.") {
+        super(message);
+    }
+}
+
+export class PlanNotFoundException extends DomainException {
+    constructor(message: string = "El plan especificado no fue encontrado.") {
+        super(message);
+    }
+}

--- a/src/memberships/domain/repositories/plan.repository.ts
+++ b/src/memberships/domain/repositories/plan.repository.ts
@@ -1,0 +1,28 @@
+// src/memberships/domain/repositories/plan.repository.ts
+
+import { Plan } from '../entities/plan.entity';
+
+export abstract class PlanRepository {
+    /**
+     * Guarda o actualiza un plan en la persistencia.
+     * @param plan La entidad del plan a persistir.
+     */
+    abstract save(plan: Plan): Promise<void>;
+
+    /**
+     * Busca un plan por su identificador único.
+     * @param id El ID del plan.
+     * @returns La entidad del plan o null si no se encuentra.
+     */
+    abstract findById(id: string): Promise<Plan | null>;
+
+    /**
+     * Devuelve todos los planes existentes.
+     * @returns Un arreglo de todas las entidades de planes.
+     */
+    abstract findAll(): Promise<Plan[]>;
+
+    // Podríamos añadir más adelante:
+    // abstract findByName(name: string): Promise<Plan | null>;
+    // abstract delete(id: string): Promise<void>; // Para borrado físico si se necesitara
+}

--- a/src/memberships/infrastructure/controllers/dtos/create-plan.dto.ts
+++ b/src/memberships/infrastructure/controllers/dtos/create-plan.dto.ts
@@ -1,0 +1,45 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsString, IsNotEmpty, IsNumber, Min, IsIn } from 'class-validator';
+import { PlanDurationUnit } from 'src/memberships/domain/entities/plan.entity';
+
+export class CreatePlanDto {
+    @ApiProperty({
+        description: 'El nombre del plan.',
+        example: 'Plan Mensual Premium',
+    })
+    @IsString()
+    @IsNotEmpty()
+    name: string;
+
+    @ApiProperty({
+        description: 'Una descripción detallada del plan y sus beneficios.',
+        example: 'Acceso ilimitado a todas las áreas y clases grupales.',
+    })
+    @IsString()
+    @IsNotEmpty()
+    description: string;
+
+    @ApiProperty({
+        description: 'El precio del plan en la moneda local (ej: CLP).',
+        example: 45000,
+    })
+    @IsNumber()
+    @Min(0.01)
+    price: number;
+
+    @ApiProperty({
+        description: 'El valor numérico de la duración del plan.',
+        example: 1,
+    })
+    @IsNumber()
+    @Min(1)
+    durationValue: number;
+
+    @ApiProperty({
+        description: 'La unidad de tiempo para la duración del plan.',
+        enum: ['days', 'months', 'years'],
+        example: 'months',
+    })
+    @IsIn(['days', 'months', 'years'])
+    durationUnit: PlanDurationUnit;
+}

--- a/src/memberships/infrastructure/controllers/dtos/plan-response.dto.ts
+++ b/src/memberships/infrastructure/controllers/dtos/plan-response.dto.ts
@@ -1,0 +1,25 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { PlanDurationUnit } from "src/memberships/domain/entities/plan.entity";
+
+export class PlanResponseDto {
+    @ApiProperty({ description: 'El ID único del plan (UUID).', example: 'a1b2c3d4-e5f6-7890-1234-567890abcdef' })
+    id: string;
+
+    @ApiProperty({ description: 'El nombre del plan.', example: 'Plan Mensual Premium' })
+    name: string;
+
+    @ApiProperty({ description: 'Descripción detallada del plan.', example: 'Acceso ilimitado a todas las áreas.' })
+    description: string;
+
+    @ApiProperty({ description: 'El precio del plan.', example: 45000 })
+    price: number;
+
+    @ApiProperty({ description: 'Valor numérico de la duración.', example: 1 })
+    durationValue: number;
+
+    @ApiProperty({ description: 'Unidad de tiempo de la duración.', enum: ['days', 'months', 'years'], example: 'months' })
+    durationUnit: PlanDurationUnit;
+
+    @ApiProperty({ description: 'Indica si el plan está activo y puede ser vendido.', example: true })
+    isActive: boolean;
+}

--- a/src/memberships/infrastructure/controllers/dtos/update-plan.dto.ts
+++ b/src/memberships/infrastructure/controllers/dtos/update-plan.dto.ts
@@ -1,0 +1,45 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsString, IsOptional, IsNumber, Min, IsIn, IsBoolean } from 'class-validator';
+import { PlanDurationUnit } from 'src/memberships/domain/entities/plan.entity';
+
+export class UpdatePlanDto {
+    @ApiProperty({
+        description: 'El nuevo nombre del plan.',
+        example: 'Plan Mensual Gold',
+        required: false, // <-- Indica que es opcional
+    })
+    @IsOptional()
+    @IsString()
+    name?: string;
+
+    @ApiProperty({
+        description: 'La nueva descripción del plan.',
+        example: 'Acceso a todas las áreas excepto clases premium.',
+        required: false,
+    })
+    @IsOptional()
+    @IsString()
+    description?: string;
+
+    @ApiProperty({ description: 'El nuevo precio del plan.', example: 50000, required: false })
+    @IsOptional()
+    @IsNumber()
+    @Min(0.01)
+    price?: number;
+
+    @ApiProperty({ description: 'El nuevo valor numérico de la duración.', example: 3, required: false })
+    @IsOptional()
+    @IsNumber()
+    @Min(1)
+    durationValue?: number;
+
+    @ApiProperty({ description: 'La nueva unidad de tiempo para la duración.', enum: ['days', 'months', 'years'], example: 'months', required: false })
+    @IsOptional()
+    @IsIn(['days', 'months', 'years'])
+    durationUnit?: PlanDurationUnit;
+
+    @ApiProperty({ description: 'Establece si el plan está activo o inactivo.', example: false, required: false })
+    @IsOptional()
+    @IsBoolean()
+    isActive?: boolean;
+}

--- a/src/memberships/infrastructure/controllers/memberships.controller.ts
+++ b/src/memberships/infrastructure/controllers/memberships.controller.ts
@@ -1,0 +1,85 @@
+import { Controller, Post, Body, HttpCode, HttpStatus, Patch, Param, Delete, Get } from '@nestjs/common';
+import { CreatePlanUseCase } from 'src/memberships/application/create-plan.use-case';
+import { CreatePlanDto } from './dtos/create-plan.dto';
+import { UpdatePlanDto } from './dtos/update-plan.dto';
+import { UpdatePlanUseCase } from 'src/memberships/application/update-plan.use-case';
+import { DeactivatePlanUseCase } from 'src/memberships/application/deactivate-plan.use-case';
+import { ActivatePlanUseCase } from 'src/memberships/application/activate-plan.use-case';
+import { FindAllPlansUseCase } from 'src/memberships/application/find-all-plans.use-case';
+import { FindOnePlanUseCase } from 'src/memberships/application/find-one-plan.use-case';
+import { PlanResponseDto } from './dtos/plan-response.dto';
+import { ApiTags, ApiOperation, ApiResponse, ApiParam } from '@nestjs/swagger';
+
+@ApiTags('Plans')
+@Controller('plans')
+export class MembershipsController {
+    constructor(
+        private readonly createPlanUseCase: CreatePlanUseCase,
+        private readonly updatePlanUseCase: UpdatePlanUseCase,
+        private readonly deactivatePlanUseCase: DeactivatePlanUseCase,
+        private readonly activatePlanUseCase: ActivatePlanUseCase,
+        private readonly findAllPlansUseCase: FindAllPlansUseCase,
+        private readonly findOnePlanUseCase: FindOnePlanUseCase,
+    ) { }
+
+    @Get()
+    @HttpCode(HttpStatus.OK)
+    @ApiOperation({ summary: 'Crear un nuevo plan de membresía' })
+    @ApiResponse({ status: 201, description: 'El plan fue creado exitosamente.' })
+    @ApiResponse({ status: 400, description: 'Los datos proporcionados son inválidos.' })
+    async findAll(): Promise<PlanResponseDto[]> {
+        return this.findAllPlansUseCase.execute();
+    }
+
+    @Get(':id')
+    @HttpCode(HttpStatus.OK)
+    @ApiOperation({ summary: 'Obtener una lista de todos los planes' })
+    @ApiResponse({ status: 200, description: 'Lista de planes recuperada exitosamente.', type: [PlanResponseDto] })
+    async findOne(@Param('id') id: string): Promise<PlanResponseDto> {
+        return this.findOnePlanUseCase.execute({ id });
+    }
+
+    @Post()
+    @HttpCode(HttpStatus.CREATED)
+    @ApiOperation({ summary: 'Obtener un plan por su ID' })
+    @ApiParam({ name: 'id', description: 'El ID del plan a buscar (UUID)' })
+    @ApiResponse({ status: 200, description: 'Plan encontrado.', type: PlanResponseDto })
+    @ApiResponse({ status: 404, description: 'El plan con el ID especificado no fue encontrado.' })
+    async create(@Body() createPlanDto: CreatePlanDto): Promise<void> {
+        await this.createPlanUseCase.execute(createPlanDto);
+    }
+
+    @Patch(':id')
+    @HttpCode(HttpStatus.NO_CONTENT)
+    @ApiOperation({ summary: 'Modificar un plan existente' })
+    @ApiParam({ name: 'id', description: 'El ID del plan a modificar (UUID)' })
+    @ApiResponse({ status: 204, description: 'El plan fue modificado exitosamente.' })
+    @ApiResponse({ status: 404, description: 'Plan no encontrado.' })
+    @ApiResponse({ status: 400, description: 'Datos inválidos.' })
+    async update(
+        @Param('id') id: string,
+        @Body() updatePlanDto: UpdatePlanDto,
+    ): Promise<void> {
+        await this.updatePlanUseCase.execute({ id, ...updatePlanDto });
+    }
+
+    @Delete(':id')
+    @HttpCode(HttpStatus.NO_CONTENT)
+    @ApiOperation({ summary: 'Desactivar un plan (Soft Delete)' })
+    @ApiParam({ name: 'id', description: 'El ID del plan a desactivar (UUID)' })
+    @ApiResponse({ status: 204, description: 'El plan fue desactivado exitosamente.' })
+    @ApiResponse({ status: 404, description: 'Plan no encontrado.' })
+    async delete(@Param('id') id: string): Promise<void> {
+        await this.deactivatePlanUseCase.execute({ id });
+    }
+
+    @Post(':id/activate')
+    @HttpCode(HttpStatus.NO_CONTENT)
+    @ApiOperation({ summary: 'Reactivar un plan desactivado' })
+    @ApiParam({ name: 'id', description: 'El ID del plan a reactivar (UUID)' })
+    @ApiResponse({ status: 204, description: 'El plan fue reactivado exitosamente.' })
+    @ApiResponse({ status: 404, description: 'Plan no encontrado.' })
+    async activate(@Param('id') id: string): Promise<void> {
+        await this.activatePlanUseCase.execute({ id });
+    }
+}

--- a/src/memberships/infrastructure/persistence/firestore-plan.repository.ts
+++ b/src/memberships/infrastructure/persistence/firestore-plan.repository.ts
@@ -1,0 +1,88 @@
+import { Inject, Injectable } from '@nestjs/common';
+import { Firestore, DocumentData } from 'firebase-admin/firestore';
+import { FIRESTORE_PROVIDER } from 'src/firebase/firebase.module';
+import { Plan } from 'src/memberships/domain/entities/plan.entity';
+import { PlanRepository } from 'src/memberships/domain/repositories/plan.repository';
+
+@Injectable()
+export class FirestorePlanRepository extends PlanRepository {
+    // El nombre de la colección en Firestore
+    private readonly collectionName = 'plans';
+
+    constructor(
+        @Inject(FIRESTORE_PROVIDER)
+        private readonly firestore: Firestore,
+    ) {
+        super();
+    }
+
+    // ---- MÉTODOS DE MAPEO (TRADUCCIÓN) ----
+
+    /**
+     * Convierte una entidad Plan a un objeto plano para Firestore.
+     */
+    private toPersistence(plan: Plan): any {
+        return {
+            id: plan.id,
+            name: plan.getName(),
+            description: plan.getDescription(),
+            price: plan.getPrice(),
+            durationValue: plan.getDurationValue(),
+            durationUnit: plan.getDurationUnit(),
+            isActive: plan.getIsActive(),
+        };
+    }
+
+    /**
+     * Convierte datos crudos de Firestore a una entidad Plan.
+     */
+    private toDomain(data: DocumentData): Plan {
+        return Plan.create({
+            id: data.id,
+            name: data.name,
+            description: data.description,
+            price: data.price,
+            durationValue: data.durationValue,
+            durationUnit: data.durationUnit,
+            isActive: data.isActive,
+        });
+    }
+
+    // ---- IMPLEMENTACIÓN DE LOS MÉTODOS DEL CONTRATO ----
+
+    async save(plan: Plan): Promise<void> {
+        const planData = this.toPersistence(plan);
+        await this.firestore
+            .collection(this.collectionName)
+            .doc(plan.id)
+            .set(planData);
+    }
+
+    async findById(id: string): Promise<Plan | null> {
+        const doc = await this.firestore
+            .collection(this.collectionName)
+            .doc(id)
+            .get();
+
+        if (!doc.exists) {
+            return null;
+        }
+
+        const data = doc.data();
+        if (!data) {
+            return null;
+        }
+
+        return this.toDomain(data);
+    }
+
+    async findAll(): Promise<Plan[]> {
+        const snapshot = await this.firestore.collection(this.collectionName).get();
+        if (snapshot.empty) {
+            return [];
+        }
+        return snapshot.docs
+            .map((doc) => this.toDomain(doc.data()))
+            .filter(Boolean);
+    }
+}

--- a/src/memberships/memberships.module.ts
+++ b/src/memberships/memberships.module.ts
@@ -1,0 +1,31 @@
+import { Module } from '@nestjs/common';
+import { FirebaseModule } from 'src/firebase/firebase.module';
+import { PlanRepository } from './domain/repositories/plan.repository';
+import { FirestorePlanRepository } from './infrastructure/persistence/firestore-plan.repository';
+import { MembershipsController } from './infrastructure/controllers/memberships.controller';
+import { CreatePlanUseCase } from './application/create-plan.use-case';
+import { UpdatePlanUseCase } from './application/update-plan.use-case';
+import { DeactivatePlanUseCase } from './application/deactivate-plan.use-case';
+import { ActivatePlanUseCase } from './application/activate-plan.use-case';
+import { FindAllPlansUseCase } from './application/find-all-plans.use-case';
+import { FindOnePlanUseCase } from './application/find-one-plan.use-case';
+
+@Module({
+    imports: [
+        FirebaseModule,
+    ],
+    controllers: [MembershipsController],
+    providers: [
+        {
+            provide: PlanRepository,
+            useClass: FirestorePlanRepository,
+        },
+        CreatePlanUseCase,
+        UpdatePlanUseCase,
+        DeactivatePlanUseCase,
+        ActivatePlanUseCase,
+        FindAllPlansUseCase,
+        FindOnePlanUseCase,
+    ],
+})
+export class MembershipsModule { }


### PR DESCRIPTION
Se desarrolla la primera funcionalidad completa del contexto de membresías, implementando todas las operaciones CRUD para la entidad `Plan`, siguiendo la arquitectura DDD establecida.

- **Capa de Dominio:** Se modela la entidad `Plan` con su lógica de negocio encapsulada, validaciones, métodos de comportamiento y excepciones de dominio personalizadas. Se define la interfaz `PlanRepository`.

- **Capa de Aplicación:** Se crean los casos de uso para cada operación: crear, actualizar, desactivar (soft-delete), activar, buscar uno y buscar todos.

- **Capa de Infraestructura:**
  - Se implementa `FirestorePlanRepository` para la persistencia en Firestore.
  - Se desarrolla el `MembershipsController` para exponer los casos de uso a través de una API RESTful.
  - Se crean los DTOs (`CreatePlanDto`, `UpdatePlanDto`, `PlanResponseDto`) con validaciones.

- **Documentación:**
  - Se añade documentación completa con Swagger para todos los nuevos endpoints, incluyendo descripciones, ejemplos y posibles respuestas.
  - Se crea un `README.md` a nivel del módulo (`src/memberships`) que detalla su arquitectura y funcionamiento interno.